### PR TITLE
Support filtering resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "onFileSystem:osc-logs",
     "onCommand:osc.copyAccountId",
     "onCommand:osc.showAccountId",
-    "onCommand:osc.disableResourceFolder"
+    "onCommand:osc.disableResourceFolder",
+    "onCommand:osc.editFilters"
   ],
   "main": "./out/main.js",
   "contributes": {
@@ -125,6 +126,11 @@
         "command": "osc.disableResourceFolder",
         "title": "Hide",
         "icon": "$(eye-closed)"
+      },
+      {
+        "command": "osc.editFilters",
+        "title": "Edit Filters",
+        "icon": "$(filter)"
       }
     ],
     "viewsContainers": {
@@ -214,6 +220,11 @@
           "command": "osc.disableResourceFolder",
           "when": "view == profile && viewItem =~ /foldernode$/",
           "group": "inline@3"
+        },
+        {
+          "command": "osc.editFilters",
+          "when": "view == profile && viewItem =~ /filterfoldernode$/",
+          "group": "inline@1"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -73,13 +73,13 @@
       },
       {
         "command": "profile.configure",
-        "title": "Configure",
-        "icon": "$(gear)"
+        "title": "View Profile configuration",
+        "icon": "$(organization)"
       },
       {
         "command": "profile.addEntry",
         "title": "Add",
-        "icon": "$(gist-new)"
+        "icon": "$(person-add)"
       },
       {
         "command": "osc.showResource",
@@ -161,17 +161,17 @@
         {
           "command": "profile.refreshEntry",
           "when": "view == profile",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "profile.configure",
           "when": "view == profile",
-          "group": "navigation"
+          "group": "navigation@2"
         },
         {
           "command": "profile.addEntry",
           "when": "view == profile",
-          "group": "navigation"
+          "group": "navigation@3"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "onCommand:osc.copyAccountId",
     "onCommand:osc.showAccountId",
     "onCommand:osc.disableResourceFolder",
-    "onCommand:osc.editFilters"
+    "onCommand:osc.editFilters",
+    "onCommand:osc.resetFilters"
   ],
   "main": "./out/main.js",
   "contributes": {
@@ -131,6 +132,11 @@
         "command": "osc.editFilters",
         "title": "Edit Filters",
         "icon": "$(filter)"
+      },
+      {
+        "command": "osc.resetFilters",
+        "title": "Reset Filters",
+        "icon": "$(clear-all)"
       }
     ],
     "viewsContainers": {
@@ -225,6 +231,11 @@
           "command": "osc.editFilters",
           "when": "view == profile && viewItem =~ /filterfoldernode$/",
           "group": "inline@1"
+        },
+        {
+          "command": "osc.resetFilters",
+          "when": "view == profile && viewItem == filterfoldernode",
+          "group": "inline@2"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,11 @@
         "icon": "$(person-add)"
       },
       {
+        "command": "osc.openParameter",
+        "title": "Open Parameter",
+        "icon": "$(gear)"
+      },
+      {
         "command": "osc.showResource",
         "title": "Get"
       },
@@ -172,6 +177,11 @@
           "command": "profile.addEntry",
           "when": "view == profile",
           "group": "navigation@3"
+        },
+        {
+          "command": "osc.openParameter",
+          "when": "view == profile",
+          "group": "navigation@4"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
           "type": "array",
           "default": [],
           "description": "Disable specified folders."
+        },
+        "osc-viewer.filters": {
+          "type": "object",
+          "default": {},
+          "description": "Filters for reading resources."
         }
       }
     },

--- a/src/cloud/accesskeys.ts
+++ b/src/cloud/accesskeys.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersAccessKeys } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource AccessKey
-export function getAccessKeys(profile: Profile): Promise<Array<osc.AccessKey> | string> {
+export function getAccessKeys(profile: Profile, filters?: FiltersAccessKeys): Promise<Array<osc.AccessKey> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadAccessKeysOperationRequest = {
-        readAccessKeysRequest: {}
+        readAccessKeysRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.AccessKeyApi(config);

--- a/src/cloud/apiaccessrules.ts
+++ b/src/cloud/apiaccessrules.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersApiAccessRule } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource ApiAccessRule
-export function getApiAccessRules(profile: Profile): Promise<Array<osc.ApiAccessRule> | string> {
+export function getApiAccessRules(profile: Profile, filters?: FiltersApiAccessRule): Promise<Array<osc.ApiAccessRule> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadApiAccessRulesOperationRequest = {
-        readApiAccessRulesRequest: {}
+        readApiAccessRulesRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.ApiAccessRuleApi(config);

--- a/src/cloud/cas.ts
+++ b/src/cloud/cas.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersCa } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource Ca
-export function getCas(profile: Profile): Promise<Array<osc.Ca> | string> {
+export function getCas(profile: Profile, filters?: FiltersCa): Promise<Array<osc.Ca> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadCasOperationRequest = {
-        readCasRequest: {}
+        readCasRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.CaApi(config);

--- a/src/cloud/clientgateways.ts
+++ b/src/cloud/clientgateways.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersClientGateway } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource ClientGateway
-export function getClientGateways(profile: Profile): Promise<Array<osc.ClientGateway> | string> {
+export function getClientGateways(profile: Profile, filters?: FiltersClientGateway): Promise<Array<osc.ClientGateway> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadClientGatewaysOperationRequest = {
-        readClientGatewaysRequest: {}
+        readClientGatewaysRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.ClientGatewayApi(config);

--- a/src/cloud/dhcpoptions.ts
+++ b/src/cloud/dhcpoptions.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersDhcpOptions } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource DhcpOption
-export function getDhcpOptions(profile: Profile): Promise<Array<osc.DhcpOptionsSet> | string> {
+export function getDhcpOptions(profile: Profile, filters?: FiltersDhcpOptions): Promise<Array<osc.DhcpOptionsSet> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadDhcpOptionsOperationRequest = {
-        readDhcpOptionsRequest: {}
+        readDhcpOptionsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.DhcpOptionApi(config);

--- a/src/cloud/directlinkinterfaces.ts
+++ b/src/cloud/directlinkinterfaces.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersDirectLinkInterface } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource DirectLinkInterface
-export function getDirectLinkInterfaces(profile: Profile): Promise<Array<osc.DirectLinkInterfaces> | string> {
+export function getDirectLinkInterfaces(profile: Profile, filters?: FiltersDirectLinkInterface): Promise<Array<osc.DirectLinkInterfaces> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadDirectLinkInterfacesOperationRequest = {
-        readDirectLinkInterfacesRequest: {}
+        readDirectLinkInterfacesRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.DirectLinkInterfaceApi(config);

--- a/src/cloud/directlinks.ts
+++ b/src/cloud/directlinks.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersDirectLink } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource DirectLink
-export function getDirectLinks(profile: Profile): Promise<Array<osc.DirectLink> | string> {
+export function getDirectLinks(profile: Profile, filters?: FiltersDirectLink): Promise<Array<osc.DirectLink> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadDirectLinksOperationRequest = {
-        readDirectLinksRequest: {}
+        readDirectLinksRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.DirectLinkApi(config);

--- a/src/cloud/flexiblegpus.ts
+++ b/src/cloud/flexiblegpus.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersFlexibleGpu } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource FlexibleGpu
-export function getFlexibleGpus(profile: Profile): Promise<Array<osc.FlexibleGpu> | string> {
+export function getFlexibleGpus(profile: Profile, filters?: FiltersFlexibleGpu): Promise<Array<osc.FlexibleGpu> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadFlexibleGpusOperationRequest = {
-        readFlexibleGpusRequest: {}
+        readFlexibleGpusRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.FlexibleGpuApi(config);

--- a/src/cloud/internetservices.ts
+++ b/src/cloud/internetservices.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersInternetService } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource InternetService
-export function getInternetServices(profile: Profile): Promise<Array<osc.InternetService> | string> {
+export function getInternetServices(profile: Profile, filters?: FiltersInternetService): Promise<Array<osc.InternetService> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadInternetServicesOperationRequest = {
-        readInternetServicesRequest: {}
+        readInternetServicesRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.InternetServiceApi(config);

--- a/src/cloud/keypairs.ts
+++ b/src/cloud/keypairs.ts
@@ -2,12 +2,15 @@
 import * as osc from "outscale-api";
 import { getConfig } from './cloud';
 import { Profile } from "../flat/node";
+import { FiltersKeypair } from "outscale-api";
 
 
-export function getKeypairs(profile: Profile): Promise<Array<osc.Keypair> | string> {
+export function getKeypairs(profile: Profile, filters?: FiltersKeypair): Promise<Array<osc.Keypair> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadKeypairsOperationRequest = {
-        readKeypairsRequest: {}
+        readKeypairsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.KeypairApi(config);

--- a/src/cloud/loadbalancers.ts
+++ b/src/cloud/loadbalancers.ts
@@ -2,12 +2,15 @@
 import * as osc from "outscale-api";
 import { getConfig } from './cloud';
 import { Profile } from "../flat/node";
+import { FiltersLoadBalancer } from "outscale-api";
 
 
-export function getLoadBalancers(profile: Profile): Promise<Array<osc.LoadBalancer> | string> {
+export function getLoadBalancers(profile: Profile, filters?: FiltersLoadBalancer): Promise<Array<osc.LoadBalancer> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadLoadBalancersOperationRequest = {
-        readLoadBalancersRequest: {}
+        readLoadBalancersRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.LoadBalancerApi(config);

--- a/src/cloud/natservices.ts
+++ b/src/cloud/natservices.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersNatService } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource NatService
-export function getNatServices(profile: Profile): Promise<Array<osc.NatService> | string> {
+export function getNatServices(profile: Profile, filters?: FiltersNatService): Promise<Array<osc.NatService> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadNatServicesOperationRequest = {
-        readNatServicesRequest: {}
+        readNatServicesRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.NatServiceApi(config);

--- a/src/cloud/netaccesspoints.ts
+++ b/src/cloud/netaccesspoints.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersNetAccessPoint } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource NetAccessPoint
-export function getNetAccessPoints(profile: Profile): Promise<Array<osc.NetAccessPoint> | string> {
+export function getNetAccessPoints(profile: Profile, filters?: FiltersNetAccessPoint): Promise<Array<osc.NetAccessPoint> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadNetAccessPointsOperationRequest = {
-        readNetAccessPointsRequest: {}
+        readNetAccessPointsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.NetAccessPointApi(config);

--- a/src/cloud/netpeerings.ts
+++ b/src/cloud/netpeerings.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersNetPeering } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource NetPeering
-export function getNetPeerings(profile: Profile): Promise<Array<osc.NetPeering> | string> {
+export function getNetPeerings(profile: Profile, filters?: FiltersNetPeering): Promise<Array<osc.NetPeering> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadNetPeeringsOperationRequest = {
-        readNetPeeringsRequest: {}
+        readNetPeeringsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.NetPeeringApi(config);

--- a/src/cloud/nets.ts
+++ b/src/cloud/nets.ts
@@ -2,12 +2,15 @@
 import * as osc from "outscale-api";
 import { getConfig } from './cloud';
 import { Profile } from "../flat/node";
+import { FiltersNet } from "outscale-api";
 
 
-export function getNets(profile: Profile): Promise<Array<osc.Net> | string> {
+export function getNets(profile: Profile, filters?: FiltersNet): Promise<Array<osc.Net> | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadNetsOperationRequest = {
-        readNetsRequest: {}
+        readNetsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.NetApi(config);

--- a/src/cloud/nics.ts
+++ b/src/cloud/nics.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersNic } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource Nic
-export function getNics(profile: Profile): Promise<Array<osc.Nic> | string> {
+export function getNics(profile: Profile, filters?: FiltersNic): Promise<Array<osc.Nic> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadNicsOperationRequest = {
-        readNicsRequest: {}
+        readNicsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.NicApi(config);

--- a/src/cloud/publicips.ts
+++ b/src/cloud/publicips.ts
@@ -2,12 +2,15 @@
 import * as osc from "outscale-api";
 import { getConfig } from './cloud';
 import { Profile } from "../flat/node";
+import { FiltersPublicIp } from "outscale-api";
 
 
-export function getExternalIPs(profile: Profile): Promise<Array<osc.PublicIp> | string> {
+export function getExternalIPs(profile: Profile, filters?: FiltersPublicIp): Promise<Array<osc.PublicIp> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadPublicIpsOperationRequest = {
-        readPublicIpsRequest: {}
+        readPublicIpsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.PublicIpApi(config);

--- a/src/cloud/routetables.ts
+++ b/src/cloud/routetables.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersRouteTable } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource RouteTable
-export function getRouteTables(profile: Profile): Promise<Array<osc.RouteTable> | string> {
+export function getRouteTables(profile: Profile, filters?: FiltersRouteTable): Promise<Array<osc.RouteTable> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadRouteTablesOperationRequest = {
-        readRouteTablesRequest: {}
+        readRouteTablesRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.RouteTableApi(config);

--- a/src/cloud/securitygroups.ts
+++ b/src/cloud/securitygroups.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersSecurityGroup } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource SecurityGroup
-export function getSecurityGroups(profile: Profile): Promise<Array<osc.SecurityGroup> | string> {
+export function getSecurityGroups(profile: Profile, filters?: FiltersSecurityGroup): Promise<Array<osc.SecurityGroup> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadSecurityGroupsOperationRequest = {
-        readSecurityGroupsRequest: {}
+        readSecurityGroupsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.SecurityGroupApi(config);

--- a/src/cloud/snapshots.ts
+++ b/src/cloud/snapshots.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersSnapshot } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource Snapshot
-export function getSnapshots(profile: Profile): Promise<Array<osc.Snapshot> | string> {
+export function getSnapshots(profile: Profile, filters?: FiltersSnapshot): Promise<Array<osc.Snapshot> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadSnapshotsOperationRequest = {
-        readSnapshotsRequest: {}
+        readSnapshotsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.SnapshotApi(config);

--- a/src/cloud/subnets.ts
+++ b/src/cloud/subnets.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersSubnet } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource Subnet
-export function getSubnets(profile: Profile): Promise<Array<osc.Subnet> | string> {
+export function getSubnets(profile: Profile, filters?: FiltersSubnet): Promise<Array<osc.Subnet> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadSubnetsOperationRequest = {
-        readSubnetsRequest: {}
+        readSubnetsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.SubnetApi(config);

--- a/src/cloud/virtualgateways.ts
+++ b/src/cloud/virtualgateways.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersVirtualGateway } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource VirtualGateway
-export function getVirtualGateways(profile: Profile): Promise<Array<osc.VirtualGateway> | string> {
+export function getVirtualGateways(profile: Profile, filters?: FiltersVirtualGateway): Promise<Array<osc.VirtualGateway> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadVirtualGatewaysOperationRequest = {
-        readVirtualGatewaysRequest: {}
+        readVirtualGatewaysRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.VirtualGatewayApi(config);

--- a/src/cloud/vms.ts
+++ b/src/cloud/vms.ts
@@ -1,11 +1,14 @@
 import * as osc from "outscale-api";
 import { getConfig } from './cloud';
 import { Profile } from "../flat/node";
+import { FiltersVm } from "outscale-api";
 
-export function getVms(profile: Profile): Promise<Array<osc.Vm> | string> {
+export function getVms(profile: Profile, filters?: FiltersVm): Promise<Array<osc.Vm> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadVmsOperationRequest = {
-        readVmsRequest: {}
+        readVmsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.VmApi(config);

--- a/src/cloud/volumes.ts
+++ b/src/cloud/volumes.ts
@@ -2,12 +2,15 @@
 import * as osc from "outscale-api";
 import { getConfig } from './cloud';
 import { Profile } from "../flat/node";
+import { FiltersVolume } from "outscale-api";
 
 
-export function getVolumes(profile: Profile): Promise<Array<osc.Volume> | string> {
+export function getVolumes(profile: Profile, filters?: FiltersVolume): Promise<Array<osc.Volume> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadVolumesOperationRequest = {
-        readVolumesRequest: {}
+        readVolumesRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.VolumeApi(config);

--- a/src/cloud/vpnconnections.ts
+++ b/src/cloud/vpnconnections.ts
@@ -1,14 +1,17 @@
 
 import * as osc from "outscale-api";
+import { FiltersVpnConnection } from "outscale-api";
 import { getConfig } from '../cloud/cloud';
 import { Profile } from "../flat/node";
 
 
 // Retrieve all items of the resource VpnConnection
-export function getVpnConnections(profile: Profile): Promise<Array<osc.VpnConnection> | string> {
+export function getVpnConnections(profile: Profile, filters?: FiltersVpnConnection): Promise<Array<osc.VpnConnection> | string> {
     const config = getConfig(profile);
     const readParameters : osc.ReadVpnConnectionsOperationRequest = {
-        readVpnConnectionsRequest: {}
+        readVpnConnectionsRequest: {
+            filters: filters
+        }
     };
 
     const api = new osc.VpnConnectionApi(config);

--- a/src/config_file/action.editFilters.ts
+++ b/src/config_file/action.editFilters.ts
@@ -1,0 +1,104 @@
+import { MultiStepInput} from './multistep';
+import { QuickPickItem} from 'vscode';
+import { FiltersFolderNode } from '../flat/folders/node.filterfolder';
+import { FILTERS_PARAMETER, getConfigurationParameter, updateConfigurationParameter } from '../configuration/utils';
+
+/**
+ * A multi-step input using window.createQuickPick() and window.createInputBox().
+ * 
+ * This first part uses the helper class `MultiStepInput` that wraps the API for the multi-step case.
+ */
+ export async function editFilters(resource: FiltersFolderNode<any>) {
+
+
+	interface State {
+		title: string;
+		step: number;
+		totalSteps: number;
+		filterName: string;
+		filterValue: string;
+	}
+
+	async function collectInputs() {
+		const state = {} as Partial<State>;
+		await MultiStepInput.run(input => inputFilterName(input, state));
+	}
+
+	const title = `Edit Filters of ${resource.folderName}`;
+	const resourceName = resource.folderName;
+	const steps = 2;
+
+	function capitalizeFirstLetter(value: string) {
+		return value.charAt(0).toUpperCase() + value.slice(1);
+	}
+
+	async function inputFilterName(input: MultiStepInput, state: Partial<State>) {
+		const quickPickItems: Array<QuickPickItem> = [];
+		for (const el of Object.keys(resource.filtersFromJson("{}"))) {
+			quickPickItems.push({
+				label: capitalizeFirstLetter(el)
+			});
+		}
+		const item = await input.showQuickPick({
+			title,
+			step: 1,
+			totalSteps: steps,
+			items: quickPickItems,
+			activeItem: quickPickItems[0],
+			placeholder: "Which filter to select ?",
+			shouldResume: shouldResume
+		});
+		state.filterName = item.label;
+		return (input: MultiStepInput) => inputValue(input, state);
+	}
+
+	async function inputValue(input: MultiStepInput, state: Partial<State>) {
+		const filters = getConfigurationParameter<any>(FILTERS_PARAMETER);
+		let value = '';
+		if (!(resourceName in filters)) {
+			filters[resourceName] = {};
+		}
+		if (typeof state.filterName !== 'undefined') {
+			if (state.filterName in filters[resourceName]) {
+				value = JSON.stringify(filters[resourceName][state.filterName]);
+			}
+		}
+		
+		state.filterValue = await input.showInputBox({
+			title,
+			step: 2,
+			totalSteps: steps,
+			value: value,
+			prompt: 'Enter Filter Value',
+			validate: valideJSON,
+			shouldResume: shouldResume
+		});
+
+
+
+		if (typeof state.filterName !== 'undefined') {
+			filters[resourceName][state.filterName] = JSON.parse(state.filterValue);
+		}
+
+		await updateConfigurationParameter(FILTERS_PARAMETER, filters);
+	}
+
+	function shouldResume() {
+		// Could show a notification with the option to resume.
+		return new Promise<boolean>(() => {
+			// noop
+		});
+	}
+
+	async function valideJSON(params: string) {
+		try{
+			JSON.parse(params);
+			return undefined;
+		} catch (e){
+			return 'The value is incorrect. It should be a valid JSON';
+		}
+	}
+
+	await collectInputs();
+
+}

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -13,5 +13,5 @@ export function getConfigurationParameter<T>(parameter: string):  T | undefined 
 
 export async function updateConfigurationParameter(parameter: string, value: any) {
     const conf = vscode.workspace.getConfiguration(CONFIGURATION_NAME);
-    conf.update(parameter, value, true).then();
+    await conf.update(parameter, value, true);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,6 +161,10 @@ export function activate(context: vscode.ExtensionContext) {
 		await vscode.commands.executeCommand('profile.refreshEntry');
 	});
 
+	vscode.commands.registerCommand('osc.openParameter', async () => {
+		vscode.commands.executeCommand('workbench.action.openSettings', '@ext:outscale.osc-viewer');
+	});
+
 }
 // this method is called when your extension is deactivated
 export function deactivate() { 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,9 @@ import { OscVirtualContentProvider } from './virtual_filesystem/oscvirtualfs';
 import { LogsProvider } from './virtual_filesystem/logs';
 import { ProfileNode } from './flat/node.profile';
 import { FolderNode } from './flat/folders/node.folder';
-import { DISABLE_FOLDER_PARAMETER, FILTERS_PARAMETER, getConfigurationParameter, updateConfigurationParameter } from './configuration/utils';
+import { FiltersFolderNode } from './flat/folders/node.filterfolder';
+import { DISABLE_FOLDER_PARAMETER, getConfigurationParameter, updateConfigurationParameter } from './configuration/utils';
+import { editFilters } from './config_file/action.editFilters';
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -143,6 +145,12 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 		await updateConfigurationParameter(DISABLE_FOLDER_PARAMETER, disableFolder);
 
+		// Refresh the profile
+		await vscode.commands.executeCommand('profile.refreshEntry');
+	});
+
+	vscode.commands.registerCommand('osc.editFilters', async (arg: FiltersFolderNode<any>) => {
+		await editFilters(arg);
 		// Refresh the profile
 		await vscode.commands.executeCommand('profile.refreshEntry');
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,6 +155,11 @@ export function activate(context: vscode.ExtensionContext) {
 		await vscode.commands.executeCommand('profile.refreshEntry');
 	});
 
+	vscode.commands.registerCommand('osc.resetFilters', async (arg: FiltersFolderNode<any>) => {
+		await arg.resetFilters();
+		// Refresh the profile
+		await vscode.commands.executeCommand('profile.refreshEntry');
+	});
 
 }
 // this method is called when your extension is deactivated

--- a/src/flat/folders/node.filterfolder.ts
+++ b/src/flat/folders/node.filterfolder.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode';
+import { FiltersVpnConnection, FiltersNetAccessPoint, FiltersNet, FiltersCa, FiltersSnapshot, FiltersFlexibleGpu, FiltersNic, FiltersDirectLink, FiltersApiAccessRule, FiltersLoadBalancer, FiltersKeypair, FiltersNetPeering, FiltersVolume, FiltersSubnet, FiltersDirectLinkInterface, FiltersClientGateway, FiltersNatService, FiltersSecurityGroup, FiltersRouteTable, FiltersImage, FiltersInternetService, FiltersVm, FiltersVirtualGateway, FiltersPublicIp } from 'outscale-api';
+import { ThemeIcon } from 'vscode';
+import { FILTERS_PARAMETER, getConfigurationParameter, updateConfigurationParameter } from '../../configuration/utils';
+import { Profile } from '../node';
+import { FolderNode } from './node.folder';
+
+export type  FiltersType = FiltersVpnConnection | FiltersNetAccessPoint | FiltersNet | FiltersCa | FiltersSnapshot | FiltersFlexibleGpu | FiltersNic | FiltersDirectLink | FiltersApiAccessRule | FiltersLoadBalancer | FiltersKeypair | FiltersNetPeering | FiltersVolume | FiltersSubnet | FiltersDirectLinkInterface | FiltersClientGateway | FiltersNatService | FiltersSecurityGroup | FiltersRouteTable | FiltersImage | FiltersInternetService | FiltersVm | FiltersVirtualGateway | FiltersPublicIp;
+export abstract class FiltersFolderNode<T> extends FolderNode {
+
+	filters: T | undefined;
+    constructor(readonly profile: Profile, readonly folderName: string) {
+		super(profile, folderName);
+		this.updateFilters();
+    }
+
+    getContextValue(): string {
+        if (typeof this.filters === 'undefined') {
+            return "emptyfilterfoldernode";
+        }
+        return "filterfoldernode";
+	}
+
+    getTreeItem(): vscode.TreeItem {
+		const treeItem = super.getTreeItem();
+        if (typeof this.filters !== 'undefined') {
+            treeItem.iconPath = new ThemeIcon("filter-filled");
+        }
+
+        return treeItem;
+	}
+
+
+	updateFilters(): void {
+        const filters = getConfigurationParameter<any>(FILTERS_PARAMETER);
+        if (this.folderName in filters) {
+            this.filters = this.filtersFromJson(filters[this.folderName]);
+        }
+    }
+
+	abstract filtersFromJson(json: string): T;
+
+}

--- a/src/flat/folders/node.filterfolder.ts
+++ b/src/flat/folders/node.filterfolder.ts
@@ -11,6 +11,7 @@ export abstract class FiltersFolderNode<T> extends FolderNode {
 	filters: T | undefined;
     constructor(readonly profile: Profile, readonly folderName: string) {
 		super(profile, folderName);
+        this.filters = undefined;
 		this.updateFilters();
     }
 
@@ -30,6 +31,14 @@ export abstract class FiltersFolderNode<T> extends FolderNode {
         return treeItem;
 	}
 
+    async resetFilters(): Promise<void> {
+        const filters = getConfigurationParameter<any>(FILTERS_PARAMETER);
+        if (this.folderName in filters) {
+            filters[this.folderName] = undefined;
+        }
+        await updateConfigurationParameter(FILTERS_PARAMETER, filters);
+        this.filters = undefined;
+    }
 
 	updateFilters(): void {
         const filters = getConfigurationParameter<any>(FILTERS_PARAMETER);

--- a/src/flat/folders/simple/node.folder.accesskey.ts
+++ b/src/flat/folders/simple/node.folder.accesskey.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteAccessKey, getAccessKeys } from '../../../cloud/accesskeys';
+import { FiltersAccessKeys, FiltersAccessKeysFromJSON } from 'outscale-api';
 
 export const ACCESSKEY_FOLDER_NAME = "Access Keys";
-export class AccessKeysFolderNode extends FolderNode implements ExplorerFolderNode {
-    constructor(readonly profile: Profile) {
+export class AccessKeysFolderNode extends FiltersFolderNode<FiltersAccessKeys> implements ExplorerFolderNode {
+	constructor(readonly profile: Profile) {
 		super(profile, ACCESSKEY_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getAccessKeys(this.profile).then(results => {
+		this.updateFilters();
+		return getAccessKeys(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class AccessKeysFolderNode extends FolderNode implements ExplorerFolderNo
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersAccessKeys {
+		return FiltersAccessKeysFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.apiaccessrule.ts
+++ b/src/flat/folders/simple/node.folder.apiaccessrule.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteApiAccessRule, getApiAccessRules } from '../../../cloud/apiaccessrules';
+import { FiltersApiAccessRule, FiltersApiAccessRuleFromJSON } from 'outscale-api';
 
 export const APIACCESSRULES_FOLDER_NAME="Api Access Rules";
-export class ApiAccessRulesFolderNode extends FolderNode implements ExplorerFolderNode {
+export class ApiAccessRulesFolderNode extends FiltersFolderNode<FiltersApiAccessRule> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, APIACCESSRULES_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getApiAccessRules(this.profile).then(results => {
+		this.updateFilters();
+		return getApiAccessRules(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class ApiAccessRulesFolderNode extends FolderNode implements ExplorerFold
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersApiAccessRule {
+		return FiltersApiAccessRuleFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.ca.ts
+++ b/src/flat/folders/simple/node.folder.ca.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteCa, getCas } from '../../../cloud/cas';
+import { FiltersCa, FiltersCaFromJSON } from 'outscale-api';
 
 export const CA_FOLDER_NAME="Cas";
-export class CasFolderNode extends FolderNode implements ExplorerFolderNode {
+export class CasFolderNode extends FiltersFolderNode<FiltersCa> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, CA_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getCas(this.profile).then(results => {
+		this.updateFilters();
+		return getCas(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class CasFolderNode extends FolderNode implements ExplorerFolderNode {
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersCa {
+		return FiltersCaFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.clientgateway.ts
+++ b/src/flat/folders/simple/node.folder.clientgateway.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteClientGateway, getClientGateways } from '../../../cloud/clientgateways';
+import { FiltersClientGateway, FiltersClientGatewayFromJSON } from 'outscale-api';
 
 export const CLIENTGATEWAYS_FOLDER_NAME="Client Gateways";
-export class ClientGatewaysFolderNode extends FolderNode implements ExplorerFolderNode {
+export class ClientGatewaysFolderNode extends FiltersFolderNode<FiltersClientGateway> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, CLIENTGATEWAYS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getClientGateways(this.profile).then(results => {
+		this.updateFilters();
+		return getClientGateways(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class ClientGatewaysFolderNode extends FolderNode implements ExplorerFold
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersClientGateway {
+		return FiltersClientGatewayFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.dhcpoption.ts
+++ b/src/flat/folders/simple/node.folder.dhcpoption.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteDhcpOption, getDhcpOptions } from '../../../cloud/dhcpoptions';
+import { FiltersDhcpOptions, FiltersDhcpOptionsFromJSON } from 'outscale-api';
 
 export const DHCPOPTIONS_FOLDER_NAME="Dhcp Options";
-export class DhcpOptionsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class DhcpOptionsFolderNode extends FiltersFolderNode<FiltersDhcpOptions> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, DHCPOPTIONS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getDhcpOptions(this.profile).then(results => {
+		this.updateFilters();
+		return getDhcpOptions(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class DhcpOptionsFolderNode extends FolderNode implements ExplorerFolderN
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersDhcpOptions {
+		return FiltersDhcpOptionsFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.directlink.ts
+++ b/src/flat/folders/simple/node.folder.directlink.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteDirectLink, getDirectLinks } from '../../../cloud/directlinks';
+import { FiltersDirectLink, FiltersDirectLinkFromJSON } from 'outscale-api';
 
 export const DIRECTLINKS_FOLDER_NAME="DirectLinks";
-export class DirectLinksFolderNode extends FolderNode implements ExplorerFolderNode {
+export class DirectLinksFolderNode extends FiltersFolderNode<FiltersDirectLink> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, DIRECTLINKS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getDirectLinks(this.profile).then(results => {
+		this.updateFilters();
+		return getDirectLinks(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class DirectLinksFolderNode extends FolderNode implements ExplorerFolderN
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersDirectLink {
+		return FiltersDirectLinkFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.directlinkinterface.ts
+++ b/src/flat/folders/simple/node.folder.directlinkinterface.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteDirectLinkInterface, getDirectLinkInterfaces } from '../../../cloud/directlinkinterfaces';
+import { FiltersDirectLinkInterface, FiltersDirectLinkInterfaceFromJSON } from 'outscale-api';
 
 export const DIRECTLINKINTERFACES_FOLDER_NAME="DirectLink Interfaces";
-export class DirectLinkInterfacesFolderNode extends FolderNode implements ExplorerFolderNode {
+export class DirectLinkInterfacesFolderNode extends FiltersFolderNode<FiltersDirectLinkInterface> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, DIRECTLINKINTERFACES_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getDirectLinkInterfaces(this.profile).then(results => {
+		this.updateFilters();
+		return getDirectLinkInterfaces(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class DirectLinkInterfacesFolderNode extends FolderNode implements Explor
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersDirectLinkInterface {
+		return FiltersDirectLinkInterfaceFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.flexiblegpu.ts
+++ b/src/flat/folders/simple/node.folder.flexiblegpu.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteFlexibleGpu, getFlexibleGpus } from '../../../cloud/flexiblegpus';
+import { FiltersFlexibleGpu, FiltersFlexibleGpuFromJSON } from 'outscale-api';
 
 export const FLEXIBLEGPUS_FOLDER_NAME="Flexible Gpus";
-export class FlexibleGpusFolderNode extends FolderNode implements ExplorerFolderNode {
+export class FlexibleGpusFolderNode extends FiltersFolderNode<FiltersFlexibleGpu> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, FLEXIBLEGPUS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getFlexibleGpus(this.profile).then(results => {
+		this.updateFilters();
+		return getFlexibleGpus(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class FlexibleGpusFolderNode extends FolderNode implements ExplorerFolder
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersFlexibleGpu {
+		return FiltersFlexibleGpuFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.internetservice.ts
+++ b/src/flat/folders/simple/node.folder.internetservice.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteInternetService, getInternetServices } from '../../../cloud/internetservices';
+import { FiltersInternetService, FiltersInternetServiceFromJSON } from 'outscale-api';
 
 export const INTERNETSERVICES_FOLDER_NAME="Internet Services";
-export class InternetServicesFolderNode extends FolderNode implements ExplorerFolderNode {
+export class InternetServicesFolderNode extends FiltersFolderNode<FiltersInternetService> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, INTERNETSERVICES_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getInternetServices(this.profile).then(results => {
+		this.updateFilters();
+		return getInternetServices(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class InternetServicesFolderNode extends FolderNode implements ExplorerFo
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersInternetService {
+		return FiltersInternetServiceFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.keypair.ts
+++ b/src/flat/folders/simple/node.folder.keypair.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteKeypair, getKeypairs } from '../../../cloud/keypairs';
+import { FiltersKeypair, FiltersKeypairFromJSON } from 'outscale-api';
 
 export const KEYPAIRS_FOLDER_NAME="Keypairs";
-export class KeypairsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class KeypairsFolderNode extends FiltersFolderNode<FiltersKeypair> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, KEYPAIRS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getKeypairs(this.profile).then(result => {
+		this.updateFilters();
+		return getKeypairs(this.profile, this.filters).then(result => {
 			if (typeof result === "string") {
 				vscode.window.showErrorMessage(result);
 				return Promise.resolve([]);
@@ -27,4 +29,8 @@ export class KeypairsFolderNode extends FolderNode implements ExplorerFolderNode
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersKeypair {
+		return FiltersKeypairFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.loadbalancer.ts
+++ b/src/flat/folders/simple/node.folder.loadbalancer.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { deleteLoadBalancer, getLoadBalancers } from '../../../cloud/loadbalancers';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
+import { FiltersLoadBalancer, FiltersLoadBalancerFromJSON } from 'outscale-api';
 
 export const LOADBALANCER_FOLDER_NAME="LoadBalancers";
-export class LoadBalancerFolderNode extends FolderNode implements ExplorerFolderNode {
+export class LoadBalancerFolderNode extends FiltersFolderNode<FiltersLoadBalancer> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, LOADBALANCER_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getLoadBalancers(this.profile).then(result => {
+		this.updateFilters();
+		return getLoadBalancers(this.profile, this.filters).then(result => {
 			if (typeof result === "string") {
 				vscode.window.showErrorMessage(result);
 				return Promise.resolve([]);
@@ -27,4 +29,8 @@ export class LoadBalancerFolderNode extends FolderNode implements ExplorerFolder
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersLoadBalancer {
+		return FiltersLoadBalancerFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.natservice.ts
+++ b/src/flat/folders/simple/node.folder.natservice.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteNatService, getNatServices } from '../../../cloud/natservices';
+import { FiltersNatService, FiltersNatServiceFromJSON } from 'outscale-api';
 
 export const NATSERVICES_FOLDER_NAME="Nat Services";
-export class NatServicesFolderNode extends FolderNode implements ExplorerFolderNode {
+export class NatServicesFolderNode extends FiltersFolderNode<FiltersNatService> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, NATSERVICES_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getNatServices(this.profile).then(results => {
+		this.updateFilters();
+		return getNatServices(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class NatServicesFolderNode extends FolderNode implements ExplorerFolderN
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersNatService {
+		return FiltersNatServiceFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.net.ts
+++ b/src/flat/folders/simple/node.folder.net.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteNet, getNets } from '../../../cloud/nets';
+import { FiltersNet, FiltersNetFromJSON } from 'outscale-api';
 
 export const NET_FOLDER_NAME="Nets";
-export class VpcFolderNode extends FolderNode implements ExplorerFolderNode {
+export class VpcFolderNode extends FiltersFolderNode<FiltersNet> implements ExplorerFolderNode {
 	constructor(readonly profile: Profile) {
 		super(profile, NET_FOLDER_NAME);
 	}
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getNets(this.profile).then(netsResults => {
+		this.updateFilters();
+		return getNets(this.profile, this.filters).then(netsResults => {
 			if (typeof netsResults === "string") {
 				vscode.window.showErrorMessage(netsResults);
 				return Promise.resolve([]);
@@ -26,6 +28,10 @@ export class VpcFolderNode extends FolderNode implements ExplorerFolderNode {
 			return Promise.resolve(resources);
 		});
 
+	}
+
+	filtersFromJson(json: string): FiltersNet {
+		return FiltersNetFromJSON(json);
 	}
 
 }

--- a/src/flat/folders/simple/node.folder.netaccesspoint.ts
+++ b/src/flat/folders/simple/node.folder.netaccesspoint.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteNetAccessPoint, getNetAccessPoints } from '../../../cloud/netaccesspoints';
+import { FiltersNetAccessPoint, FiltersNetAccessPointFromJSON } from 'outscale-api';
 
 export const NETACCESSPOINTS_FOLDER_NAME="Net AccessPoints";
-export class NetAccessPointsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class NetAccessPointsFolderNode extends FiltersFolderNode<FiltersNetAccessPoint> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, NETACCESSPOINTS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getNetAccessPoints(this.profile).then(results => {
+		this.updateFilters();
+		return getNetAccessPoints(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class NetAccessPointsFolderNode extends FolderNode implements ExplorerFol
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersNetAccessPoint {
+		return FiltersNetAccessPointFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.netpeering.ts
+++ b/src/flat/folders/simple/node.folder.netpeering.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteNetPeering, getNetPeerings } from '../../../cloud/netpeerings';
+import { FiltersNetPeering, FiltersNetPeeringFromJSON } from 'outscale-api';
 
 export const NETPEERINGS_FOLDER_NAME="Net Peerings";
-export class NetPeeringsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class NetPeeringsFolderNode extends FiltersFolderNode<FiltersNetPeering> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, NETPEERINGS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getNetPeerings(this.profile).then(results => {
+		this.updateFilters();
+		return getNetPeerings(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class NetPeeringsFolderNode extends FolderNode implements ExplorerFolderN
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersNetPeering {
+		return FiltersNetPeeringFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.nic.ts
+++ b/src/flat/folders/simple/node.folder.nic.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteNic, getNics } from '../../../cloud/nics';
+import { FiltersNic, FiltersNicFromJSON } from 'outscale-api';
 
 export const NICS_FOLDER_NAME="Nics";
-export class NicsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class NicsFolderNode extends FiltersFolderNode<FiltersNic> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, NICS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getNics(this.profile).then(results => {
+		this.updateFilters();
+		return getNics(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class NicsFolderNode extends FolderNode implements ExplorerFolderNode {
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersNic {
+		return FiltersNicFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.routetable.ts
+++ b/src/flat/folders/simple/node.folder.routetable.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteRouteTable, getRouteTables } from '../../../cloud/routetables';
+import { FiltersRouteTable, FiltersRouteTableFromJSON } from 'outscale-api';
 
 export const ROUTETABLES_FOLDER_NAME="Route tables";
-export class RouteTablesFolderNode extends FolderNode implements ExplorerFolderNode {
+export class RouteTablesFolderNode extends FiltersFolderNode<FiltersRouteTable> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, ROUTETABLES_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getRouteTables(this.profile).then(result => {
+		this.updateFilters();
+		return getRouteTables(this.profile, this.filters).then(result => {
 			if (typeof result === "string") {
 				vscode.window.showErrorMessage(result);
 				return Promise.resolve([]);
@@ -27,4 +29,8 @@ export class RouteTablesFolderNode extends FolderNode implements ExplorerFolderN
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersRouteTable {
+		return FiltersRouteTableFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.securitygroup.ts
+++ b/src/flat/folders/simple/node.folder.securitygroup.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteSecurityGroup, getSecurityGroups } from '../../../cloud/securitygroups';
+import { FiltersSecurityGroup, FiltersSecurityGroupFromJSON } from 'outscale-api';
 
 export const SECURITYGROUPS_FOLDER_NAME="Security Groups";
-export class SecurityGroupsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class SecurityGroupsFolderNode extends FiltersFolderNode<FiltersSecurityGroup> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, SECURITYGROUPS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getSecurityGroups(this.profile).then(sgsResults => {
+		this.updateFilters();
+		return getSecurityGroups(this.profile, this.filters).then(sgsResults => {
 			if (typeof sgsResults === "string") {
 				vscode.window.showErrorMessage(sgsResults);
 				return Promise.resolve([]);
@@ -27,4 +29,8 @@ export class SecurityGroupsFolderNode extends FolderNode implements ExplorerFold
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersSecurityGroup {
+		return FiltersSecurityGroupFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.snapshot.ts
+++ b/src/flat/folders/simple/node.folder.snapshot.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteSnapshot, getSnapshots } from '../../../cloud/snapshots';
+import { FiltersSnapshot, FiltersSnapshotFromJSON } from 'outscale-api';
 
 export const SNAPSHOTS_FOLDER_NAME="Snapshots";
-export class SnapshotsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class SnapshotsFolderNode extends FiltersFolderNode<FiltersSnapshot> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, SNAPSHOTS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getSnapshots(this.profile).then(result => {
+		this.updateFilters();
+		return getSnapshots(this.profile, this.filters).then(result => {
 			if (typeof result === "string") {
 				vscode.window.showErrorMessage(result);
 				return Promise.resolve([]);
@@ -27,4 +29,9 @@ export class SnapshotsFolderNode extends FolderNode implements ExplorerFolderNod
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersSnapshot {
+		return FiltersSnapshotFromJSON(json);
+	}
+
 }

--- a/src/flat/folders/simple/node.folder.subnet.ts
+++ b/src/flat/folders/simple/node.folder.subnet.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteSubnet, getSubnets } from '../../../cloud/subnets';
+import { FiltersSubnet, FiltersSubnetFromJSON } from 'outscale-api';
 
 export const SUBNETS_FOLDER_NAME= "Subnets";
-export class SubnetsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class SubnetsFolderNode extends FiltersFolderNode<FiltersSubnet> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, SUBNETS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getSubnets(this.profile).then(results => {
+		this.updateFilters();
+		return getSubnets(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class SubnetsFolderNode extends FolderNode implements ExplorerFolderNode 
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersSubnet {
+		return FiltersSubnetFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.virtualgateway.ts
+++ b/src/flat/folders/simple/node.folder.virtualgateway.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteVirtualGateway, getVirtualGateways } from '../../../cloud/virtualgateways';
+import { FiltersVirtualGateway, FiltersVirtualGatewayFromJSON } from 'outscale-api';
 
 export const VIRTUALGATEWAYS_FOLDER_NAME="Virtual Gateways";
-export class VirtualGatewaysFolderNode extends FolderNode implements ExplorerFolderNode {
+export class VirtualGatewaysFolderNode extends FiltersFolderNode<FiltersVirtualGateway> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, VIRTUALGATEWAYS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getVirtualGateways(this.profile).then(results => {
+		this.updateFilters();
+		return getVirtualGateways(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class VirtualGatewaysFolderNode extends FolderNode implements ExplorerFol
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersVirtualGateway {
+		return FiltersVirtualGatewayFromJSON(json);
+	}
 }

--- a/src/flat/folders/simple/node.folder.vpnconnection.ts
+++ b/src/flat/folders/simple/node.folder.vpnconnection.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
+import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
 import { deleteVpnConnection, getVpnConnections } from '../../../cloud/vpnconnections';
+import { FiltersVpnConnection, FiltersVpnConnectionFromJSON } from 'outscale-api';
 
 export const VPNCONNECTIONS_FOLDER_NAME="Vpn Connections";
-export class VpnConnectionsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class VpnConnectionsFolderNode extends FiltersFolderNode<FiltersVpnConnection> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, VPNCONNECTIONS_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getVpnConnections(this.profile).then(results => {
+		this.updateFilters();
+		return getVpnConnections(this.profile, this.filters).then(results => {
 			if (typeof results === "string") {
 				vscode.window.showErrorMessage(results);
 				return Promise.resolve([]);
@@ -31,4 +33,8 @@ export class VpnConnectionsFolderNode extends FolderNode implements ExplorerFold
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersVpnConnection {
+		return FiltersVpnConnectionFromJSON(json);
+	}
 }

--- a/src/flat/folders/specific/node.folder.publicip.ts
+++ b/src/flat/folders/specific/node.folder.publicip.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
 import { getExternalIPs } from '../../../cloud/publicips';
 import { PublicIpResourceNode } from '../../resources/node.resources.eip';
+import { FiltersPublicIp, FiltersPublicIpFromJSON } from 'outscale-api';
+import { FiltersFolderNode } from '../node.filterfolder';
 
 export const PUBLICIP_FOLDER_NAME = "External IPs";
-export class ExternalIPsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class ExternalIPsFolderNode extends FiltersFolderNode<FiltersPublicIp> implements ExplorerFolderNode {
     constructor(readonly profile: Profile) {
 		super(profile, PUBLICIP_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getExternalIPs(this.profile).then(result => {
+		this.updateFilters();
+		return getExternalIPs(this.profile, this.filters).then(result => {
 			if (typeof result === "string") {
 				vscode.window.showErrorMessage(result);
 				return Promise.resolve([]);
@@ -27,4 +29,8 @@ export class ExternalIPsFolderNode extends FolderNode implements ExplorerFolderN
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersPublicIp {
+		return FiltersPublicIpFromJSON(json);
+	}
 }

--- a/src/flat/folders/specific/node.folder.vm.ts
+++ b/src/flat/folders/specific/node.folder.vm.ts
@@ -1,19 +1,22 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
 import { getVmName, getVms } from '../../../cloud/vms';
 import { VmResourceNode } from '../../resources/node.resources.vms';
+import { FiltersVm, FiltersVmFromJSON } from 'outscale-api';
+import { FiltersFolderNode } from '../node.filterfolder';
 
 
 const filteredState = ["pending","running", "stopping", "stopped", "shutting-down"];
 export const VM_FOLDER_NAME = "Vms";
-export class VmsFolderNode extends FolderNode implements ExplorerFolderNode {
+export class VmsFolderNode extends FiltersFolderNode<FiltersVm> implements ExplorerFolderNode {
+  
     constructor(readonly profile: Profile) {
         super(profile, VM_FOLDER_NAME);
     }
 
     getChildren(): Thenable<ExplorerNode[]> {
-        return getVms(this.profile).then(vmsResult => {
+        this.updateFilters();
+        return getVms(this.profile, this.filters).then(vmsResult => {
             if (typeof vmsResult === "string") {
                 vscode.window.showErrorMessage(vmsResult);
                 return Promise.resolve([]);
@@ -37,6 +40,10 @@ export class VmsFolderNode extends FolderNode implements ExplorerFolderNode {
             return Promise.resolve(resources);
         });
 
+    }
+
+    filtersFromJson(json: string): FiltersVm {
+        return FiltersVmFromJSON(json);
     }
 
 }

--- a/src/flat/folders/specific/node.folder.volume.ts
+++ b/src/flat/folders/specific/node.folder.volume.ts
@@ -1,17 +1,20 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile } from '../../node';
-import { FolderNode } from '../node.folder';
 import { getVolumes } from '../../../cloud/volumes';
 import { VolumeResourceNode } from '../../resources/node.resources.volumes';
+import { FiltersVolume, FiltersVolumeFromJSON } from 'outscale-api';
+import { FiltersFolderNode } from '../node.filterfolder';
 
 export const VOLUME_FOLDER_NAME = "Volumes";
-export class VolumeFolderNode extends FolderNode implements ExplorerFolderNode {
+export class VolumeFolderNode extends FiltersFolderNode<FiltersVolume> implements ExplorerFolderNode {
+	
     constructor(readonly profile: Profile) {
 		super(profile, VOLUME_FOLDER_NAME);
     }
 
 	getChildren(): Thenable<ExplorerNode[]> {
-		return getVolumes(this.profile).then(result => {
+		this.updateFilters();
+		return getVolumes(this.profile, this.filters).then(result => {
 			if (typeof result === "string") {
 				vscode.window.showErrorMessage(result);
 				return Promise.resolve([]);
@@ -27,4 +30,8 @@ export class VolumeFolderNode extends FolderNode implements ExplorerFolderNode {
 		});
 		
     }
+
+	filtersFromJson(json: string): FiltersVolume {
+		return FiltersVolumeFromJSON(json);
+	}
 }


### PR DESCRIPTION
Closes #23 

**Proposed Solution**
The user will be able to filter resource for all accounts (not yet per account) by using parameter (persistent filters)
![Persistent filters](https://user-images.githubusercontent.com/91073311/195379852-51568d27-c9be-4d55-983d-fa51e679c4c1.png)
The parameter syntax is:
```json
{
  "<Resource Type 1>" : <Json of the filter>,
  "<Resource Type 2>" : <Json of the filter>
}
```
The filtered resources will be tagged with an icon
![Capture d’écran 2022-10-12 à 17 06 33](https://user-images.githubusercontent.com/91073311/195380022-0d6815ab-61a9-4857-b5a1-82eb84727ee9.png)

The user will be able to remove tag with a button
![Capture d’écran 2022-10-12 à 17 06 43](https://user-images.githubusercontent.com/91073311/195380074-ed67edc6-fe2f-421a-9ffb-c79308e55c50.png)


For the user, the easy way to add is using the GUI
![filters](https://user-images.githubusercontent.com/91073311/195600235-e35253c8-0254-4355-8ce1-6cd7286b9daa.gif)

**WARNING**: there is no check of the validity of the filter value type therefore if we provide a boolean and  the API requests an array, it will be an error during the read